### PR TITLE
Fixes #7288 - configure module load path correctly

### DIFF
--- a/lib/kafo_parsers/puppet_module_parser.rb
+++ b/lib/kafo_parsers/puppet_module_parser.rb
@@ -40,7 +40,12 @@ module KafoParsers
         @@puppet_initialized = true
       end
 
-      env = Puppet::Node::Environment.new
+      # if create is available (3.5.0+) we use it to set modulepath, otherwise puppet loads files from pwd
+      if Puppet::Node::Environment.respond_to?(:create)
+        env = Puppet::Node::Environment.create(Puppet.settings.value(:environment), [File.dirname(file)])
+      else
+        env = Puppet::Node::Environment.new
+      end
       parser = Puppet::Parser::Parser.new(env)
       parser.import(@file)
 


### PR DESCRIPTION
@domcleal I'd appreciate if you could look at this since you touched this area in 2dd74a283cd407b98fb1a4cb42bc8a761b11d418

EDIT: the `create` public api was added in 3.5.0 - https://github.com/puppetlabs/puppet/blob/3.5.0/lib/puppet/node/environment.rb#L79
