### PR TITLE
Fixes #13651 - load exceptions before using them

### DIFF
--- a/kafo_parsers.gemspec
+++ b/kafo_parsers.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ci_reporter", "~> 1.9.0"
 
   # puppet manifests parsing
-  spec.add_dependency 'puppet'
+  spec.add_dependency 'puppet', '< 4.0.0' 
   spec.add_dependency 'rdoc', '>= 3.9.0'
 end

--- a/lib/kafo_parsers/doc_parser.rb
+++ b/lib/kafo_parsers/doc_parser.rb
@@ -2,6 +2,7 @@
 require 'rdoc'
 require 'rdoc/markup' # required for RDoc < 0.9.5
 require 'rdoc/markup/parser' # required for RDoc < 0.9.5
+require 'kafo_parsers/exceptions'
 
 module KafoParsers
   class DocParser
@@ -64,10 +65,10 @@ module KafoParsers
             if condition.nil?
               condition = value
             else
-              raise DocParseError, "Two or more conditions defined for #{name}"
+              raise KafoParsers::DocParseError, "Two or more conditions defined for #{name}"
             end
           else
-            raise DocParseError, "Unknown attribute #{name}"
+            raise KafoParsers::DocParseError, "Unknown attribute #{name}"
         end
 
       end

--- a/lib/kafo_parsers/puppet_module_parser.rb
+++ b/lib/kafo_parsers/puppet_module_parser.rb
@@ -29,7 +29,7 @@ module KafoParsers
 
     def initialize(file)
       @file = file
-      raise ModuleName, "File not found #{file}, check your answer file" unless File.exists?(file)
+      raise KafoParsers::ModuleName, "File not found #{file}, check your answer file" unless File.exists?(file)
 
       unless @@puppet_initialized
         if Puppet::PUPPETVERSION.to_i >= 3
@@ -81,7 +81,7 @@ module KafoParsers
     def docs
       data = { :docs => {}, :types => {}, :groups => {}, :conditions => {}, :object_type => '' }
       if @object.nil?
-        raise DocParseError, "no documentation found for manifest #{@file}, parsing error?"
+        raise KafoParsers::DocParseError, "no documentation found for manifest #{@file}, parsing error?"
       elsif !@object.doc.nil?
         parser             = DocParser.new(@object.doc).parse
         data[:docs]        = parser.docs


### PR DESCRIPTION
This issue prevents any error message to be properly raised from kafo_parsers.

I've bundled commit restricting puppet to < 4.0.0 as iit was breaking tests.