### PR TITLE
Fixes #7848 - introduce parser based on puppet-strings module

### DIFF
--- a/kafo_parsers.gemspec
+++ b/kafo_parsers.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ci_reporter", "~> 1.9.0"
 
   # puppet manifests parsing
-  spec.add_development_dependency 'puppet', '< 4.0.0'
+  spec.add_development_dependency 'puppet', '< 5.0.0'
   spec.add_dependency 'rdoc', '>= 3.9.0'
+  spec.add_dependency 'json'
 end

--- a/lib/kafo_parsers/exceptions.rb
+++ b/lib/kafo_parsers/exceptions.rb
@@ -8,11 +8,18 @@ module KafoParsers
 
   class ParserNotAvailable < StandardError
     def initialize(wrapped)
-      @wrapped = wrapped
+      if wrapped.is_a?(Exception)
+        @wrapped = wrapped
+      else
+        @message = wrapped
+      end
     end
 
     def message
-      @wrapped.message
+      @message || @wrapped.message
     end
+  end
+  
+  class ParseError < StandardError
   end
 end

--- a/lib/kafo_parsers/parsers.rb
+++ b/lib/kafo_parsers/parsers.rb
@@ -1,9 +1,10 @@
 require 'kafo_parsers/puppet_module_parser.rb'
+require 'kafo_parsers/puppet_strings_module_parser.rb'
 
 module KafoParsers
   module Parsers
     def self.all
-      [PuppetModuleParser]
+      [ PuppetModuleParser, PuppetStringsModuleParser ]
     end
 
     def self.find_available(options = {})

--- a/lib/kafo_parsers/puppet_strings_module_parser.rb
+++ b/lib/kafo_parsers/puppet_strings_module_parser.rb
@@ -1,0 +1,126 @@
+# encoding: UTF-8
+require 'json'
+require 'kafo_parsers/doc_parser'
+
+module KafoParsers
+  class PuppetStringsModuleParser
+    # You can call this method to get all supported information from a given manifest
+    #
+    # @param [ String ] manifest file path to parse
+    # @return [ Hash ] hash containing values, validations, documentation, types, groups and conditions
+    def self.parse(file)
+      content = new(file)
+      docs    = content.docs
+
+      # data_type must be called before other validations
+      data = {
+        :object_type => content.data_type,
+        :values      => content.values,
+        :validations => content.validations
+      }
+      data[:parameters] = data[:values].keys
+      data.merge!(docs)
+      data
+    end
+
+    def self.available?
+      `#{puppet_bin} help strings`
+      if $?.success?
+        return true
+      else
+        raise KafoParsers::ParserNotAvailable.new("#{puppet_bin} does not have strings module installed")
+      end
+    end
+
+    def initialize(file)
+      @file = file
+      raise KafoParsers::ModuleName, "File not found #{file}, check your answer file" unless File.exists?(file)
+
+      command = "#{self.class.puppet_bin} strings #{file} --emit-json-stdout"
+      @raw_json = `#{command}`
+      unless $?.success?
+        raise KafoParsers::ParseError, "'#{command}' returned error\n#{@raw_json}"
+      end
+
+      begin
+        @complete_hash = ::JSON.parse(@raw_json)
+      rescue ::JSON::ParserError => e
+        raise KafoParsers::ParseError, "'#{command}' returned invalid json output: #{e.message}\n#{@raw_json}"
+      end
+      self.data_type # we need to determine data_type before any further parsing
+
+      self
+    end
+
+    # AIO and system default puppet bins are tested for existence, fallback to just `puppet` otherwise
+    def self.puppet_bin
+      @puppet_bin ||= begin
+        found_puppet_path = (::ENV['PATH'].split(File::PATH_SEPARATOR) + ['/opt/puppetlabs/bin']).find do |path|
+          binary = File.join(path, 'puppet')
+          binary if File.executable?(binary)
+        end
+        File.join(found_puppet_path, 'puppet') || 'puppet'
+      end
+    end
+
+    def data_type
+      @data_type ||= begin
+        if (@parsed_hash = @complete_hash['puppet_classes'].find { |klass| klass['file'] == @file })
+          'hostclass'
+        elsif (@parsed_hash = @complete_hash['defined_types'].find { |klass| klass['file'] == @file })
+          'definition'
+        else
+          raise KafoParsers::ParseError, "unable to find manifest data, syntax error in manifest #{@file}?"
+        end
+      end
+    end
+
+    def values
+      Hash[@parsed_hash['parameters'].map { |name, value| [ name, sanitize(value) ] }]
+    end
+
+    # unsupported in puppet strings parser
+    def validations(param = nil)
+      []
+    end
+
+    # returns data in following form
+    # {
+    #   :docs => { $param1 => 'documentation without types and conditions'}
+    #   :types => { $param1 => 'boolean'},
+    #   :groups => { $param1 => ['Parameters', 'Advanced']},
+    #   :conditions => { $param1 => '$db_type == "mysql"'},
+    # }
+    def docs
+      data = { :docs => {}, :types => {}, :groups => {}, :conditions => {} }
+      if @parsed_hash.nil?
+        raise KafoParsers::DocParseError, "no documentation found for manifest #{@file}, parsing error?"
+      elsif !@parsed_hash['docstring'].nil?
+        parser             = DocParser.new(@parsed_hash['docstring']).parse
+        data[:docs]        = parser.docs
+        data[:groups]      = parser.groups
+        data[:types]       = parser.types
+        data[:conditions]  = parser.conditions
+      end
+      data
+    end
+
+    private
+
+    # default values using puppet strings includes $ symbol, e.g. "$::foreman::params::ssl"
+    # to keep the same API we strip $ if it's present
+    #
+    # values are reported as strings which is issue especially for :under
+    # strings are double quoted
+    # others must be typecast manually according to reported type
+    def sanitize(value)
+      if (value.start_with?("'") && value.end_with?("'")) || (value.start_with?('"') && value.end_with?('"'))
+        value = value[1..-2]
+      end
+      value = value[1..-1] if value.start_with?('$')
+      value = :undef if value == 'undef'
+
+      value
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,7 @@ BASIC_MANIFEST = <<EOS
 # === Parameters
 #
 # $version::         some version number
+# $sub_version::     some sub version string
 # $documented::      something that is documented but not used
 # $undef::           default is undef
 # $multiline::       param with multiline
@@ -52,6 +53,7 @@ BASIC_MANIFEST = <<EOS
 #
 class testing(
   $version = '1.0',
+  $sub_version = "beta",
   $undocumented = 'does not have documentation',
   $undef = undef,
   $multiline = undef,


### PR DESCRIPTION
This PR adds new manifest parser based on [puppet-strings](https://github.com/puppetlabs/puppetlabs-strings). To test you must install it from source since we need features from unreleased version. Note that it does not bring any advanced stuff from puppet 4 dsl (e.g. parameter types) but as longs as types are documented in rdoc syntax, parsing this new dsl should work. It should be possible to add more features later (e.g. use puppet types and fallback to rdoc). The only limitation is that we don't have validations support since we don't parse the code directly.

 - [x] puppet-strings must be released by puppet labs, existing version does not have json output support
 - [ ] packaging of puppet-strings module to be available when we call puppet (install into AIO stack?)
 - [x] switch kafo to start using PuppetStringsModuleParser (trivial) implemented in https://github.com/theforeman/kafo/pull/138
 - [x] optionally add an extra layer that would choose right parser for local environment #14
 - [x] optionally with ^ we could add third parser that would check for existing json output from strings and use it instead (we could create it during package build), kafo would then ask for parsers that's `ready?` and use that one