### PR TITLE
fixes #14448 - change Puppet to a soft dep, add helper to find parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,37 @@ Or install it yourself as:
 
 ## Usage
 
-To parse file and see parsed information
+To parse file using the best available parser, and see parsed information:
+```ruby
+require 'kafo_parsers/parsers'
+parser = KafoParsers::Parsers.find_available or fail('No parser available')
+hash = parser.parse('/puppet/module/manifests/init.pp')
+p hash
+```
+
+`find_available` can take a logger object that responds to `#debug` to log
+detailed reasons why each parser isn't available.
+
+```ruby
+logger = Logging.logger(STDOUT)
+logger.level = :debug
+KafoParsers::Parsers.find_available(:logger => logger)
+```
+
+To load a specific parser:
 ```ruby
 require 'kafo_parsers/puppet_module_parser'
 hash = KafoParsers::PuppetModuleParser.parse('/puppet/module/manifests/init.pp')
-p hash
 ```
+
+#### PuppetModuleParser
+
+The standard PuppetModuleParser loads Puppet as a regular library or gem, so it
+must be installed in the same Ruby that's running kafo_parsers.
+
+Only Puppet versions 2.6.x, 2.7.x and 3.x are supported.
+
+Add `gem 'puppet', '< 4'` to your application's Gemfile to use this.
 
 # License
 

--- a/kafo_parsers.gemspec
+++ b/kafo_parsers.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ci_reporter", "~> 1.9.0"
 
   # puppet manifests parsing
-  spec.add_dependency 'puppet', '< 4.0.0' 
+  spec.add_development_dependency 'puppet', '< 4.0.0'
   spec.add_dependency 'rdoc', '>= 3.9.0'
 end

--- a/lib/kafo_parsers/exceptions.rb
+++ b/lib/kafo_parsers/exceptions.rb
@@ -6,4 +6,13 @@ module KafoParsers
   class ModuleName < StandardError
   end
 
+  class ParserNotAvailable < StandardError
+    def initialize(wrapped)
+      @wrapped = wrapped
+    end
+
+    def message
+      @wrapped.message
+    end
+  end
 end

--- a/lib/kafo_parsers/parsers.rb
+++ b/lib/kafo_parsers/parsers.rb
@@ -1,0 +1,20 @@
+require 'kafo_parsers/puppet_module_parser.rb'
+
+module KafoParsers
+  module Parsers
+    def self.all
+      [PuppetModuleParser]
+    end
+
+    def self.find_available(options = {})
+      all.find do |provider|
+        begin
+          provider.available?
+        rescue ParserNotAvailable => e
+          options[:logger].debug "Provider #{provider} not available: #{e.message}"
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/kafo_parsers/puppet_module_parser.rb
+++ b/lib/kafo_parsers/puppet_module_parser.rb
@@ -1,5 +1,4 @@
 # encoding: UTF-8
-require 'puppet'
 require 'kafo_parsers/doc_parser'
 
 module KafoParsers
@@ -9,6 +8,13 @@ module KafoParsers
   # we can read from the whole manifest
   class PuppetModuleParser
     @@puppet_initialized = false
+
+    def self.available?
+      require 'puppet'
+      [2, 3].include?(Puppet::PUPPETVERSION.to_i)
+    rescue LoadError => e
+      raise KafoParsers::ParserNotAvailable.new(e)
+    end
 
     # You can call this method to get all supported information from a given manifest
     #
@@ -32,6 +38,7 @@ module KafoParsers
       raise KafoParsers::ModuleName, "File not found #{file}, check your answer file" unless File.exists?(file)
 
       unless @@puppet_initialized
+        require 'puppet'
         if Puppet::PUPPETVERSION.to_i >= 3
           Puppet.initialize_settings
         else

--- a/test/kafo_parsers/parsers_test.rb
+++ b/test/kafo_parsers/parsers_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+require 'kafo_parsers/parsers'
+
+module KafoParsers
+  describe Parsers do
+    describe ".all" do
+      specify { Parsers.all.must_be_kind_of Array }
+    end
+
+    describe ".find_available" do
+      let(:parser1) { PuppetModuleParser }
+
+      specify { Parsers.stub(:all, []) { Parsers.find_available.must_be_nil } }
+
+      specify do
+        parser1.stub(:available?, true) do
+          Parsers.stub(:all, [parser1]) { Parsers.find_available.must_equal parser1 }
+        end
+      end
+
+      specify do
+        parser1.stub(:available?, false) do
+          Parsers.stub(:all, [parser1]) { Parsers.find_available.must_be_nil }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Each parser's `.available?` method now tries to load any dependencies
and indicates if the parser is usable. An exception may be thrown with
more details.

`KafoParsers::Parsers.find_available` finds the first parser that's
available, which should be the preferred way of using kafo_parsers.

---

This should be complementary to #13.  It should have a bump to the version number when released, probably 0.1.x?