### PR TITLE
refs #14450 - remove Puppet ASTs from validations list

### DIFF
--- a/lib/kafo_parsers/validation.rb
+++ b/lib/kafo_parsers/validation.rb
@@ -1,0 +1,10 @@
+module KafoParsers
+  class Validation
+    attr_reader :name, :arguments
+
+    def initialize(name, arguments)
+      @name = name
+      @arguments = arguments
+    end
+  end
+end


### PR DESCRIPTION
Follows on from https://github.com/theforeman/kafo/pull/137.

The Kafo PR can be merged and used against kafo_parsers with or without this patch, it's meant to work with the AST objects or KafoParsers::Validation.  This just finishes removing the passing of Puppet AST objects between the two libraries.

With these, the parser cache and soft deps, it should be possible to run Kafo without loading Puppet as a library.