### PR TITLE
Move puppet dev dep to Gemfile, add puppet-strings dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,11 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in kafo_parsers.gemspec
 gemspec
+
+puppet_version = ENV['PUPPET_VERSION']
+puppet_spec = puppet_version ? "~> #{puppet_version}" : '< 5.0.0'
+gem 'puppet', puppet_spec
+
+if puppet_version.nil? || (puppet_version >= '3.7' && RUBY_VERSION >= '1.9')
+  gem 'puppet-strings'
+end

--- a/kafo_parsers.gemspec
+++ b/kafo_parsers.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ci_reporter", "~> 1.9.0"
 
   # puppet manifests parsing
-  spec.add_development_dependency 'puppet', '< 5.0.0'
   spec.add_dependency 'rdoc', '>= 3.9.0'
   spec.add_dependency 'json'
 end


### PR DESCRIPTION
The 'PUPPET_VERSION' or 'puppet' environment variables will be used to
install specific versions of Puppet, and if the version specified
supports puppet-strings, then the dep's added to test the strings
parser.

This allows the removal of Gemfile alterations from the Jenkins job and
makes it easier to test different versions in development.