### PR TITLE
fixes #14932 - set default strings parser encoding to UTF-8

### DIFF
--- a/lib/kafo_parsers/puppet_module_parser.rb
+++ b/lib/kafo_parsers/puppet_module_parser.rb
@@ -45,7 +45,7 @@ module KafoParsers
         else
           Puppet.parse_config
         end
-        Encoding.default_external = Encoding::UTF_8 if defined?(Encoding) && Encoding.respond_to?(:default_external=)
+        Encoding.default_external = Encoding::UTF_8 if defined?(Encoding)
         @@puppet_initialized = true
       end
 

--- a/lib/kafo_parsers/puppet_strings_module_parser.rb
+++ b/lib/kafo_parsers/puppet_strings_module_parser.rb
@@ -42,6 +42,7 @@ module KafoParsers
         raise KafoParsers::ParseError, "'#{command}' returned error\n#{@raw_json}"
       end
 
+      Encoding.default_external = Encoding::UTF_8 if defined?(Encoding)
       begin
         @complete_hash = ::JSON.parse(@raw_json)
       rescue ::JSON::ParserError => e

--- a/test/kafo_parsers/puppet_strings_parser_test.rb
+++ b/test/kafo_parsers/puppet_strings_parser_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'test_helper'
 require 'kafo_parsers/puppet_strings_module_parser'
 
@@ -90,6 +91,13 @@ module KafoParsers
           specify { conditions['username'].must_equal '$db_type == \'mysql\'' }
           specify { conditions['password'].must_equal '$db_type == \'mysql\' && $username != \'root\'' }
         end
+      end
+
+      describe 'with UTF-8 manifest' do
+        let(:manifest) { "# e✗amp✓e\n" + BASIC_MANIFEST.sub('class testing(', 'class testingutf8(') }
+        let(:data) { PuppetStringsModuleParser.parse(ManifestFileFactory.build(manifest).path) }
+        let(:parameters) { data[:parameters] }
+        specify { parameters.must_include 'version' }
       end
     end
   end


### PR DESCRIPTION
I suspect tests may fail until #19's merged, as I changed the Jenkins job.