### PR TITLE
refs #6158 - prefix variables in defaults with `$`

### DIFF
--- a/lib/kafo_parsers/puppet_strings_module_parser.rb
+++ b/lib/kafo_parsers/puppet_strings_module_parser.rb
@@ -113,7 +113,6 @@ module KafoParsers
     private
 
     # default values using puppet strings includes $ symbol, e.g. "$::foreman::params::ssl"
-    # to keep the same API we strip $ if it's present
     #
     # values are reported as strings which is issue especially for :under
     # strings are double quoted
@@ -122,7 +121,6 @@ module KafoParsers
       if (value.start_with?("'") && value.end_with?("'")) || (value.start_with?('"') && value.end_with?('"'))
         value = value[1..-2]
       end
-      value = value[1..-1] if value.start_with?('$')
       value = :undef if value == 'undef'
 
       value

--- a/test/kafo_parsers/puppet_module_parser_test.rb
+++ b/test/kafo_parsers/puppet_module_parser_test.rb
@@ -49,6 +49,7 @@ module KafoParsers
           specify { values['sub_version'].must_equal 'beta' }
           specify { values['undef'].must_equal :undef }
           specify { values['debug'].must_equal true }
+          specify { values['variable'].must_equal '$::testing::params::variable' }
         end
 
         describe "parsed validations" do

--- a/test/kafo_parsers/puppet_strings_parser_test.rb
+++ b/test/kafo_parsers/puppet_strings_parser_test.rb
@@ -49,6 +49,7 @@ module KafoParsers
           specify { values['sub_version'].must_equal 'beta' }
           specify { values['undef'].must_equal :undef }
           specify { values['debug'].must_equal 'true' }
+          specify { values['variable'].must_equal '$::testing::params::variable' }
         end
 
         describe "parsed validations are not supported" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,6 +51,7 @@ BASIC_MANIFEST = <<EOS
 # === Extra parameters
 #
 # $log_level::       we can get up in levels
+# $variable::        set in a params class
 # $m_i_a::
 #
 class testing(
@@ -69,6 +70,7 @@ class testing(
   $username = 'root',
   $password = 'toor',
   $file = undef,
+  $variable = $::testing::params::variable,
   $m_i_a = 'test') {
 
   validate_string($undocumented)


### PR DESCRIPTION
Uses the existing code to parse ASTs for function arguments, which already follows this format.