### PR TITLE
fixes #16858 - support parameter docs in YARD with strings parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,86 @@ hash = KafoParsers::PuppetStringsModuleParser.parse('/puppet/module/manifests/in
 Output will be similar to PuppetModuleParser, only validations are not supported,
 since they are not parsed by puppet-strings.
 
+## Documentation syntax
+
+### RDoc syntax
+
+Classes and defined types should be prefixed with a comment section with an RDoc
+block, containing a description, headings for different parameter groups and
+parameters laid out as shown below:
+
+```puppet
+# Example class that installs Example
+#
+# Supports version 1 to 3.
+#
+# === Parameters::
+#
+# $foo::  Sets the value of foo in the Example config
+#
+# === Advanced parameters::
+#
+# $bar::  Sets the value of bar in the advanced config
+```
+
+Parameters may have multi-line descriptions and can have extra attributes
+defined on new lines below them. Supports:
+
+```puppet
+# $foo::  Sets the value of foo in the Example config
+#         condition: $bar == 'use_foo'
+#         type: Optional[String]
+```
+
+Supports:
+
+* `condition:` an expression to determine if the parameter is used
+* `type:` the data type of the parameter
+
+Used by:
+
+* `PuppetModuleParser`
+* `PuppetStringsModuleParser` (but deprecated, prefer YARD)
+
+### YARD syntax
+
+Classes and defined types should be prefixed with a comment section in YARD
+following the Puppet Strings documentation standard, as shown below:
+
+```puppet
+# Example class that installs Example
+#
+# Supports version 1 to 3.
+#
+# @param foo Sets the value of foo in the Example config
+# @param bar Sets the value of bar in the advanced config
+#            group: Advanced parameters
+```
+
+Parameters may have multi-line descriptions and can have extra attributes
+defined on new lines below them. Supports:
+
+```puppet
+# @param foo Sets the value of foo in the Example config
+#            condition: $bar == 'use_foo'
+```
+
+Supports:
+
+* `condition:` an expression to determine if the parameter is used
+* `group:` comma-separated list of groups, increasing in specificity
+
+Data types are given in the parameter list of the class, or can be given inline
+for Puppet 3 compatibility:
+
+```puppet
+# @param foo [Integer] Sets the value of foo in the Example config
+```
+
+Used by:
+
+* `PuppetStringsModuleParser`
+
 # License
 
 This project is licensed under the GPLv3+.

--- a/lib/kafo_parsers/param_doc_parser.rb
+++ b/lib/kafo_parsers/param_doc_parser.rb
@@ -1,0 +1,42 @@
+require 'kafo_parsers/exceptions'
+
+module KafoParsers
+  class ParamDocParser
+    ATTRIBUTE_LINE   = /^(condition|group|type)\s*:\s*(.*)/
+
+    def initialize(param, text)
+      @param = param
+      @metadata = {}
+      parse_paragraph([text].flatten)
+    end
+
+    attr_reader :param, :doc
+    [:condition, :group, :type].each do |attr|
+      define_method(attr) do
+        @metadata[attr]
+      end
+    end
+
+    private
+
+    def parse_paragraph(text)
+      text_parts       = text.map(&:strip)
+      attributes, docs = text_parts.partition { |line| line =~ ATTRIBUTE_LINE }
+      parse_attributes(attributes)
+      @doc = docs
+    end
+
+    def parse_attributes(attributes)
+      attributes.each do |attribute|
+        data        = attribute.match(ATTRIBUTE_LINE)
+        name, value = data[1], data[2]
+        raise KafoParsers::DocParseError, "Two or more #{name} lines defined for #{param}" if @metadata.key?(name)
+        @metadata[name.to_sym] = value
+      end
+
+      if @metadata.key?(:group)
+        @metadata[:group] = @metadata[:group].split(/\s*,\s*/)
+      end
+    end
+  end
+end

--- a/lib/kafo_parsers/puppet_module_parser.rb
+++ b/lib/kafo_parsers/puppet_module_parser.rb
@@ -110,7 +110,7 @@ module KafoParsers
         parser             = DocParser.new(@object.doc).parse
         data[:docs]        = parser.docs
         data[:groups]      = parser.groups
-        data[:types]       = parser.types
+        data[:types]       = Hash.new('string').merge(parser.types)
         data[:conditions]  = parser.conditions
         data[:object_type] = @object.type.to_s
       end

--- a/test/kafo_parsers/param_doc_parser_test.rb
+++ b/test/kafo_parsers/param_doc_parser_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+require 'kafo_parsers/param_doc_parser'
+
+module KafoParsers
+  describe ParamDocParser do
+    let(:parser) { ParamDocParser.new(:example, doc) }
+
+    describe "one line" do
+      let(:doc) { "example parameter documentation" }
+      specify { parser.doc.must_equal ["example parameter documentation"] }
+      specify { parser.condition.must_be_nil }
+      specify { parser.group.must_be_nil }
+      specify { parser.type.must_be_nil }
+    end
+
+    describe "multi-line" do
+      let(:doc) { ["example parameter", "     documentation"] }
+      specify { parser.doc.must_equal ["example parameter", "documentation"] }
+      specify { parser.condition.must_be_nil }
+      specify { parser.group.must_be_nil }
+      specify { parser.type.must_be_nil }
+    end
+
+    describe "multi-line with group" do
+      let(:doc) { ["example parameter", "     documentation", "    group: Advanced parameters"] }
+      specify { parser.doc.must_equal ["example parameter", "documentation"] }
+      specify { parser.condition.must_be_nil }
+      specify { parser.group.must_equal ["Advanced parameters"] }
+      specify { parser.type.must_be_nil }
+    end
+
+    describe "multi-line with nested group" do
+      let(:doc) { ["example parameter", "     documentation", "    group: Advanced parameters,MySQL"] }
+      specify { parser.doc.must_equal ["example parameter", "documentation"] }
+      specify { parser.condition.must_be_nil }
+      specify { parser.group.must_equal ["Advanced parameters", "MySQL"] }
+      specify { parser.type.must_be_nil }
+    end
+
+    describe "multi-line with type" do
+      let(:doc) { ["example parameter", "     documentation", "    type: Optional[Hash[String, Array[Integer]]]"] }
+      specify { parser.doc.must_equal ["example parameter", "documentation"] }
+      specify { parser.condition.must_be_nil }
+      specify { parser.group.must_be_nil }
+      specify { parser.type.must_equal "Optional[Hash[String, Array[Integer]]]" }
+    end
+
+    describe "multi-line with condition" do
+      let(:doc) { ["example parameter", "     documentation", "    condition: $db_type == 'sqlite'"] }
+      specify { parser.doc.must_equal ["example parameter", "documentation"] }
+      specify { parser.condition.must_equal "$db_type == 'sqlite'" }
+      specify { parser.group.must_be_nil }
+      specify { parser.type.must_be_nil }
+    end
+  end
+end

--- a/test/kafo_parsers/puppet_strings_parser_test.rb
+++ b/test/kafo_parsers/puppet_strings_parser_test.rb
@@ -8,91 +8,106 @@ module KafoParsers
       # we skip tests for this parser if puppet-strings is not installed
       next if Gem::Specification.find_all_by_name('puppet-strings').empty?
 
-      { 'hostclass' => BASIC_MANIFEST, 'definition' => DEFINITION_MANIFEST }.each_pair do |type, manifest|
+      [
+        {:name => 'RDoc class', :type => 'hostclass', :content => BASIC_MANIFEST},
+        {:name => 'YARD class', :type => 'hostclass', :content => BASIC_YARD_MANIFEST},
+        {:name => 'RDoc define', :type => 'definition', :content => DEFINITION_MANIFEST}
+      ].each do |manifest|
+        describe manifest[:name] do
+          data = PuppetStringsModuleParser.parse(ManifestFileFactory.build(manifest[:content]).path)
 
-        data = PuppetStringsModuleParser.parse(ManifestFileFactory.build(manifest).path)
-
-        describe 'data structure' do
-          let(:keys) { data.keys }
-          specify { keys.must_include :values }
-          specify { keys.must_include :validations }
-          specify { keys.must_include :docs }
-          specify { keys.must_include :parameters }
-          specify { keys.must_include :types }
-          specify { keys.must_include :groups }
-          specify { keys.must_include :conditions }
-          specify { keys.must_include :object_type }
-        end
-
-        describe 'object_type' do
-          specify { data[:object_type].must_equal type }
-        end
-
-        let(:parameters) { data[:parameters] }
-        describe 'parsed parameters' do
-          specify { parameters.must_include 'required' }
-          specify { parameters.must_include 'version' }
-          specify { parameters.must_include 'sub_version' }
-          specify { parameters.must_include 'undocumented' }
-          specify { parameters.must_include 'undef' }
-          specify { parameters.must_include 'debug' }
-          specify { parameters.wont_include 'documented' }
-        end
-
-        describe "parsed values" do
-          let(:values) { data[:values] }
-          it 'includes values for all parameters' do
-            parameters.each { |p| values.keys.must_include p }
+          describe 'data structure' do
+            let(:keys) { data.keys }
+            specify { keys.must_include :values }
+            specify { keys.must_include :validations }
+            specify { keys.must_include :docs }
+            specify { keys.must_include :parameters }
+            specify { keys.must_include :types }
+            specify { keys.must_include :groups }
+            specify { keys.must_include :conditions }
+            specify { keys.must_include :object_type }
           end
-          specify { values['required'].must_be_nil }
-          specify { values['version'].must_equal '1.0' }
-          specify { values['sub_version'].must_equal 'beta' }
-          specify { values['undef'].must_equal :undef }
-          specify { values['debug'].must_equal 'true' }
-          specify { values['variable'].must_equal '$::testing::params::variable' }
-        end
 
-        describe "parsed validations are not supported" do
-          let(:validations) { data[:validations] }
-          specify { validations.must_be_empty }
-        end
+          describe 'object_type' do
+            specify { data[:object_type].must_equal manifest[:type] }
+          end
 
-        describe "parsed documentation" do
-          let(:docs) { data[:docs] }
-          specify { docs.keys.must_include 'documented' }
-          specify { docs.keys.must_include 'version' }
-          specify { docs.keys.must_include 'undef' }
-          specify { docs.keys.wont_include 'm_i_a' }
-          specify { docs.keys.wont_include 'undocumented' }
-          specify { docs['version'].must_equal ['some version number'] }
-          specify { docs['multiline'].must_equal ['param with multiline', 'documentation', 'consisting of 3 lines'] }
-          specify { docs['typed'].wont_include 'type:bool' }
-        end
+          let(:parameters) { data[:parameters] }
+          describe 'parsed parameters' do
+            specify { parameters.must_include 'required' }
+            specify { parameters.must_include 'version' }
+            specify { parameters.must_include 'sub_version' }
+            specify { parameters.must_include 'undocumented' }
+            specify { parameters.must_include 'undef' }
+            specify { parameters.must_include 'debug' }
+            specify { parameters.wont_include 'documented' }
+          end
 
-        describe "parsed groups" do
-          let(:groups) { data[:groups] }
-          specify { groups['version'].must_equal ['Parameters'] }
-          specify { groups['debug'].must_equal ['Advanced parameters'] }
-          specify { groups['server'].must_equal ['Advanced parameters', 'MySQL'] }
-          specify { groups['file'].must_equal ['Advanced parameters', 'Sqlite'] }
-          specify { groups['log_level'].must_equal ['Extra parameters'] }
-        end
+          describe "parsed values" do
+            let(:values) { data[:values] }
+            it 'includes values for all parameters' do
+              parameters.each { |p| values.keys.must_include p }
+            end
+            specify { values['required'].must_be_nil }
+            specify { values['version'].must_equal '1.0' }
+            specify { values['sub_version'].must_equal 'beta' }
+            specify { values['undef'].must_equal :undef }
+            specify { values['debug'].must_equal 'true' }
+            specify { values['variable'].must_equal '$::testing::params::variable' }
+          end
 
-        describe "parsed types" do
-          let(:types) { data[:types] }
-          specify { types['version'].must_equal 'Any' }
-          specify { types['typed'].must_equal 'boolean' }
-          specify { types['remote'].must_equal 'boolean' }
-        end
+          describe "parsed validations are not supported" do
+            let(:validations) { data[:validations] }
+            specify { validations.must_be_empty }
+          end
 
-        describe "parsed conditions" do
-          let(:conditions) { data[:conditions] }
-          specify { conditions['version'].must_be_nil }
-          specify { conditions['typed'].must_be_nil }
-          specify { conditions['remote'].must_equal '$db_type == \'mysql\'' }
-          specify { conditions['server'].must_equal '$db_type == \'mysql\' && $remote' }
-          specify { conditions['username'].must_equal '$db_type == \'mysql\'' }
-          specify { conditions['password'].must_equal '$db_type == \'mysql\' && $username != \'root\'' }
+          describe "parsed documentation" do
+            let(:docs) { data[:docs] }
+            specify { docs.keys.must_include 'documented' }
+            specify { docs.keys.must_include 'version' }
+            specify { docs.keys.must_include 'undef' }
+            specify { docs.keys.wont_include 'm_i_a' }
+            specify { docs.keys.wont_include 'undocumented' }
+            specify { docs['version'].must_equal ['some version number'] }
+            specify { docs['multiline'].must_equal ['param with multiline', 'documentation', 'consisting of 3 lines'] }
+            specify { docs['typed'].wont_include 'type:bool' }
+          end
+
+          describe "parsed groups" do
+            let(:groups) { data[:groups] }
+            specify do
+              skip "No default grouping of YARD parameters" if manifest[:name] == "YARD class"
+              groups['version'].must_equal ['Parameters']
+            end
+            specify { groups['debug'].must_equal ['Advanced parameters'] }
+            specify { groups['server'].must_equal ['Advanced parameters', 'MySQL'] }
+            specify { groups['file'].must_equal ['Advanced parameters', 'Sqlite'] }
+            specify { groups['log_level'].must_equal ['Extra parameters'] }
+          end
+
+          describe "parsed types" do
+            let(:types) { data[:types] }
+            specify { types['version'].must_equal 'Any' }
+            specify { types['typed'].must_equal 'boolean' }
+            specify { types['remote'].must_equal 'boolean' }
+          end
+
+          describe "parsed conditions" do
+            let(:conditions) { data[:conditions] }
+            specify { conditions['version'].must_be_nil }
+            specify { conditions['typed'].must_be_nil }
+            if manifest[:name] == "YARD class"
+              specify { conditions['remote'].must_be_nil }
+              specify { conditions['server'].must_equal '$remote' }
+              specify { conditions['username'].must_be_nil }
+              specify { conditions['password'].must_equal '$username != \'root\'' }
+            else
+              specify { conditions['remote'].must_equal '$db_type == \'mysql\'' }
+              specify { conditions['server'].must_equal '$db_type == \'mysql\' && $remote' }
+              specify { conditions['username'].must_equal '$db_type == \'mysql\'' }
+              specify { conditions['password'].must_equal '$db_type == \'mysql\' && $username != \'root\'' }
+            end
+          end
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,6 +87,75 @@ EOS
 
 DEFINITION_MANIFEST = BASIC_MANIFEST.sub('class testing(', 'define testing2(')
 
+BASIC_YARD_MANIFEST = <<EOS
+# This manifests is used for testing
+#
+# It has no value except of covering use cases that we must test.
+#
+# @param required            something without a default value
+# @param version             some version number
+# @param sub_version         some sub version string
+# @param documented          something that is documented but not used
+# @param undef               default is undef
+# @param multiline           param with multiline
+#                            documentation
+#                            consisting of 3 lines
+# @param typed [boolean]     something having its type explicitly set
+# @param multivalue [array]  list of users
+# @param m_i_a
+#
+# @param debug [boolean]     we have advanced parameter, yay!
+#                            group:Advanced parameters
+# @param db_type             can be mysql or sqlite
+#                            group:Advanced parameters
+#
+# @param remote [boolean]    socket or remote connection
+#                            group: Advanced parameters, MySQL
+# @param server              hostname
+#                            condition: $remote
+#                            group: Advanced parameters, MySQL
+# @param username            username
+#                            group: Advanced parameters, MySQL
+# @param password [password] condition:$username != 'root'
+#                            group: Advanced parameters, MySQL
+#
+# @param file                filename
+#                            group: Advanced parameters, Sqlite
+#
+# @param log_level           we can get up in levels
+#                            group: Extra parameters
+#
+class testing(
+  String $required,
+  Any $version = '1.0',
+  String $sub_version = "beta",
+  String $undocumented = 'does not have documentation',
+  Optional[Integer] $undef = undef,
+  Optional[String] $multiline = undef,
+  $typed = true,
+  $multivalue = ['x', 'y'],
+  $debug = true,
+  Enum['mysql', 'sqlite'] $db_type = 'mysql',
+  $remote = true,
+  String $server = 'mysql.example.com',
+  String $username = 'root',
+  $password = 'toor',
+  Optional[String] $file = undef,
+  String $variable = $::testing::params::variable,
+  String $m_i_a = 'test') {
+
+  validate_string($undocumented)
+  if $version == '1.0' {
+    # this must be ignored since we can't evaluate conditions
+    validate_bool($undef)
+  }
+
+  package {"testing":
+    ensure => present
+  }
+}
+EOS
+
 class Minitest::Spec
   before do
 


### PR DESCRIPTION
Puppet Strings can parse per-parameter docs in YARD format with `@param`
directives. This is now used instead of per-param docs in RDoc format if
present.

Types can be given inline if the Puppet 4 class definition syntax isn't
used and Puppet Strings will parse it automatically, e.g.

    @param example_param [String] Description

Conditions are read in the usual multi-line way, and groups are also
represented with "group: Foo" and comma-separated as there's no support
for grouping parameters in the current YARD syntax. There is no support
for group conditions.