### PR TITLE
[WIP] Add a command to convert rdoc to yardoc

### DIFF
--- a/bin/convert-to-yardoc
+++ b/bin/convert-to-yardoc
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require 'kafo_parsers/parsers'
+
+parser = KafoParsers::Parsers.find_available
+ARGV.each do |filename|
+  parsed = parser.parse(filename)
+  if parsed
+    puts "Converting #{filename}"
+    File.open(filename, 'w') do |file|
+      parsed[:parameters].each do |param|
+        file.puts "# @param #{param}\n"
+        (parsed[:docs][param] || []).each do |doc|
+          file.puts "#   #{doc}\n"
+        end
+      end
+      file.puts parsed[:source]
+    end
+  else
+    puts "Failed to parse #{filename}"
+  end
+end

--- a/kafo_parsers.gemspec
+++ b/kafo_parsers.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*'] + ['LICENSE.txt', 'Rakefile', 'README.md']
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.executables << 'convert-to-yardoc'
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"

--- a/lib/kafo_parsers/puppet_strings_module_parser.rb
+++ b/lib/kafo_parsers/puppet_strings_module_parser.rb
@@ -17,7 +17,8 @@ module KafoParsers
       data = {
         :object_type => content.data_type,
         :values      => content.values,
-        :validations => content.validations
+        :validations => content.validations,
+        :source      => content.source
       }
       data[:parameters] = data[:values].keys
       data.merge!(docs)
@@ -51,6 +52,10 @@ module KafoParsers
       self.data_type # we need to determine data_type before any further parsing
 
       self
+    end
+
+    def source
+      @parsed_hash['source']
     end
 
     # AIO and system default puppet bins are tested for existence, fallback to just `puppet` otherwise


### PR DESCRIPTION
This will be useful when deprecating the rdoc parser and moving to pure puppet-strings.

Currently missing:
* The general class documentation text is missing
* The RDoc groups aren't converted