### PR TITLE
Drop validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KafoParsers
 
-This gem can parse values, validations, documentation, types, groups and
+This gem can parse values, documentation, types, groups and
 conditions of parameters from your puppet modules. Only thing you have
 to do is provide a path to manifest file you want to be parsed.
 

--- a/kafo_parsers.gemspec
+++ b/kafo_parsers.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Marek Hulan"]
   spec.email         = ["mhulan@redhat.com"]
   spec.summary       = %q{Puppet module parsers}
-  spec.description   = %q{This gem can parse values, validations, documentation, types, groups and conditions of parameters from your puppet modules}
+  spec.description   = %q{This gem can parse values, documentation, types, groups and conditions of parameters from your puppet modules}
   spec.homepage      = "https://github.com/theforeman/kafo_parsers"
   spec.license       = "GPL-3.0+"
 

--- a/lib/kafo_parsers/puppet_strings_module_parser.rb
+++ b/lib/kafo_parsers/puppet_strings_module_parser.rb
@@ -10,16 +10,14 @@ module KafoParsers
     # You can call this method to get all supported information from a given manifest
     #
     # @param [ String ] manifest file path to parse
-    # @return [ Hash ] hash containing values, validations, documentation, types, groups and conditions
+    # @return [ Hash ] hash containing values, documentation, types, groups and conditions
     def self.parse(file)
       content = new(file)
       docs    = content.docs
 
-      # data_type must be called before other validations
       data = {
         :object_type => content.data_type,
         :values      => content.values,
-        :validations => content.validations
       }
       data[:parameters] = data[:values].keys
       data.merge!(docs)
@@ -85,11 +83,6 @@ module KafoParsers
         tag_params.select { |param| !param['types'].nil? }.map { |param| [ param['name'], nil ] } +
           @parsed_hash.fetch('defaults', {}).map { |name, value| [ name, value.nil? ? nil : sanitize(value) ] }
       ]
-    end
-
-    # unsupported in puppet strings parser
-    def validations(param = nil)
-      []
     end
 
     # returns data in following form

--- a/test/kafo_parsers/puppet_strings_parser_test.rb
+++ b/test/kafo_parsers/puppet_strings_parser_test.rb
@@ -19,7 +19,6 @@ module KafoParsers
           describe 'data structure' do
             let(:keys) { data.keys }
             specify { _(keys).must_include :values }
-            specify { _(keys).must_include :validations }
             specify { _(keys).must_include :docs }
             specify { _(keys).must_include :parameters }
             specify { _(keys).must_include :types }
@@ -56,11 +55,6 @@ module KafoParsers
             specify { _(values['mapped']).must_equal({'apples' => 'oranges', 'unquoted' => :undef}) }
             specify { _(values['debug']).must_equal 'true' }
             specify { _(values['variable']).must_equal '$::testing::params::variable' }
-          end
-
-          describe "parsed validations are not supported" do
-            let(:validations) { data[:validations] }
-            specify { _(validations).must_be_empty }
           end
 
           describe "parsed documentation" do


### PR DESCRIPTION
This is unsuspported with puppet-strings which is now the only parser. That means it can safely be dropped.

Somehow I missed this in my other cleanup branches.