### PR TITLE
Fixes #31565 - Handle arrays and hashes from strings

### DIFF
--- a/test/kafo_parsers/puppet_strings_parser_test.rb
+++ b/test/kafo_parsers/puppet_strings_parser_test.rb
@@ -52,6 +52,8 @@ module KafoParsers
             specify { values['version'].must_equal '1.0' }
             specify { values['sub_version'].must_equal 'beta' }
             specify { values['undef'].must_equal :undef }
+            specify { values['multivalue'].must_equal ['x', 'y'] }
+            specify { values['mapped'].must_equal({'apples' => 'oranges', 'unquoted' => :undef}) }
             specify { values['debug'].must_equal 'true' }
             specify { values['variable'].must_equal '$::testing::params::variable' }
           end
@@ -90,6 +92,8 @@ module KafoParsers
             specify { types['version'].must_equal 'Any' }
             specify { types['typed'].must_equal 'boolean' }
             specify { types['remote'].must_equal 'boolean' }
+            specify { types['multivalue'].must_match /^(array|Array\[String\])$/ }
+            specify { types['mapped'].must_match /^(hash|Hash\[String, Variant\[String, Integer\]\])$/ }
           end
 
           describe "parsed conditions" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,8 @@ BASIC_MANIFEST = <<EOS
 #                    type:boolean
 # $multivalue::      list of users
 #                    type:array
+# $mapped::          some mapping
+#                    type:hash
 # === Advanced parameters
 #
 # $debug::           we have advanced parameter, yay!
@@ -63,6 +65,7 @@ class testing(
   $multiline = undef,
   $typed = true,
   $multivalue = ['x', 'y'],
+  $mapped = {'apples' => 'oranges', unquoted => undef},
   $debug = true,
   $db_type = 'mysql',
   $remote = true,
@@ -101,7 +104,8 @@ BASIC_YARD_MANIFEST = <<EOS
 #                            documentation
 #                            consisting of 3 lines
 # @param typed [boolean]     something having its type explicitly set
-# @param multivalue [array]  list of users
+# @param multivalue          list of users
+# @param mapped              some mapping
 # @param m_i_a
 #
 # @param debug [boolean]     we have advanced parameter, yay!
@@ -133,7 +137,8 @@ class testing(
   Optional[Integer] $undef = undef,
   Optional[String] $multiline = undef,
   $typed = true,
-  $multivalue = ['x', 'y'],
+  Array[String] $multivalue = ['x', 'y'],
+  Hash[String, Variant[String, Integer]] $mapped = {'apples' => 'oranges', unquoted => undef},
   $debug = true,
   Enum['mysql', 'sqlite'] $db_type = 'mysql',
   $remote = true,


### PR DESCRIPTION
In the puppet-strings output hashes and arrays are literal values. This adds support for parsing them. It is very naive and it will fail if a string contains special characters that also define the structure.

This is probably good enough since in most cases we either have an empty array or trivial contents.