### PR TITLE
Drop Support for Ruby Versions <2.7

### DIFF
--- a/kafo_parsers.gemspec
+++ b/kafo_parsers.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.7', '< 4'
+
   spec.add_development_dependency "bundler", ">= 1.5", "< 3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
This PR drops support for Ruby versions <2.7 to align with modern Ruby and improve maintenance. 

For reference: https://github.com/theforeman/kafo_parsers/pull/52