### PR TITLE
Drop non-Puppet data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KafoParsers
 
-This gem can parse values, validations, documentation, types, groups and
+This gem can parse values, documentation, types, groups and
 conditions of parameters from your puppet modules. Only thing you have
 to do is provide a path to manifest file you want to be parsed.
 

--- a/kafo_parsers.gemspec
+++ b/kafo_parsers.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Marek Hulan"]
   spec.email         = ["mhulan@redhat.com"]
   spec.summary       = %q{Puppet module parsers}
-  spec.description   = %q{This gem can parse values, validations, documentation, types, groups and conditions of parameters from your puppet modules}
+  spec.description   = %q{This gem can parse values, documentation, types, groups and conditions of parameters from your puppet modules}
   spec.homepage      = "https://github.com/theforeman/kafo_parsers"
   spec.license       = "GPL-3.0+"
 

--- a/lib/kafo_parsers/doc_parser.rb
+++ b/lib/kafo_parsers/doc_parser.rb
@@ -7,7 +7,7 @@ require 'kafo_parsers/param_doc_parser'
 
 module KafoParsers
   class DocParser
-    ATTRIBUTE_LINE   = /^(condition|type)\s*:\s*(.*)/
+    ATTRIBUTE_LINE   = /^(condition)\s*:\s*(.*)/
     HEADER_CONDITION = /\A(.+)\s*condition:\s*(.+)\Z/
 
     def initialize(text)
@@ -16,11 +16,10 @@ module KafoParsers
       @docs           = {}
       @groups         = {}
       @conditions     = {}
-      @types          = {}
       @rdoc           = rdoc_parser.parse(@text)
     end
 
-    attr_reader :docs, :groups, :types, :conditions
+    attr_reader :docs, :groups, :conditions
 
     # items is array of RDoc::Markup::* on one level
     def parse(items = @rdoc.parts)
@@ -57,7 +56,6 @@ module KafoParsers
     def parse_attributes(parameter, parser)
       condition              = [current_condition, parser.condition].compact.join(' && ')
       @conditions[parameter] = condition.empty? ? nil : condition
-      @types[parameter]      = parser.type unless parser.type.nil?
     end
 
     def parse_header(heading)

--- a/lib/kafo_parsers/param_doc_parser.rb
+++ b/lib/kafo_parsers/param_doc_parser.rb
@@ -2,7 +2,7 @@ require 'kafo_parsers/exceptions'
 
 module KafoParsers
   class ParamDocParser
-    ATTRIBUTE_LINE   = /^(condition|group|type)\s*:\s*(.*)/
+    ATTRIBUTE_LINE   = /^(condition|group)\s*:\s*(.*)/
 
     def initialize(param, text)
       @param = param
@@ -11,7 +11,7 @@ module KafoParsers
     end
 
     attr_reader :param, :doc
-    [:condition, :group, :type].each do |attr|
+    [:condition, :group].each do |attr|
       define_method(attr) do
         @metadata[attr]
       end

--- a/lib/kafo_parsers/puppet_strings_module_parser.rb
+++ b/lib/kafo_parsers/puppet_strings_module_parser.rb
@@ -10,16 +10,14 @@ module KafoParsers
     # You can call this method to get all supported information from a given manifest
     #
     # @param [ String ] manifest file path to parse
-    # @return [ Hash ] hash containing values, validations, documentation, types, groups and conditions
+    # @return [ Hash ] hash containing values, documentation, types, groups and conditions
     def self.parse(file)
       content = new(file)
       docs    = content.docs
 
-      # data_type must be called before other validations
       data = {
         :object_type => content.data_type,
         :values      => content.values,
-        :validations => content.validations
       }
       data[:parameters] = data[:values].keys
       data.merge!(docs)
@@ -85,11 +83,6 @@ module KafoParsers
         tag_params.select { |param| !param['types'].nil? }.map { |param| [ param['name'], nil ] } +
           @parsed_hash.fetch('defaults', {}).map { |name, value| [ name, value.nil? ? nil : sanitize(value) ] }
       ]
-    end
-
-    # unsupported in puppet strings parser
-    def validations(param = nil)
-      []
     end
 
     # returns data in following form

--- a/lib/kafo_parsers/puppet_strings_module_parser.rb
+++ b/lib/kafo_parsers/puppet_strings_module_parser.rb
@@ -88,7 +88,7 @@ module KafoParsers
     # returns data in following form
     # {
     #   :docs => { $param1 => ['documentation without types and conditions']}
-    #   :types => { $param1 => 'boolean'},
+    #   :types => { $param1 => 'Boolean'},
     #   :groups => { $param1 => ['Parameters', 'Advanced']},
     #   :conditions => { $param1 => '$db_type == "mysql"'},
     # }
@@ -107,7 +107,6 @@ module KafoParsers
         data[:docs] = rdoc_parser.docs
         data[:groups] = rdoc_parser.groups
         data[:conditions] = rdoc_parser.conditions
-        data[:types].merge! rdoc_parser.types
 
         # Highest precedence: data in YARD @param stored in the 'text' field
         tag_params.each do |param|
@@ -117,7 +116,6 @@ module KafoParsers
             data[:docs][param_name] = param_parser.doc if param_parser.doc
             data[:groups][param_name] = param_parser.group if param_parser.group
             data[:conditions][param_name] = param_parser.condition if param_parser.condition
-            data[:types][param_name] = param_parser.type if param_parser.type
           end
         end
       end

--- a/test/kafo_parsers/param_doc_parser_test.rb
+++ b/test/kafo_parsers/param_doc_parser_test.rb
@@ -10,7 +10,6 @@ module KafoParsers
       specify { _(parser.doc).must_equal ["example parameter documentation"] }
       specify { _(parser.condition).must_be_nil }
       specify { _(parser.group).must_be_nil }
-      specify { _(parser.type).must_be_nil }
     end
 
     describe "multi-line" do
@@ -18,7 +17,6 @@ module KafoParsers
       specify { _(parser.doc).must_equal ["example parameter", "documentation"] }
       specify { _(parser.condition).must_be_nil }
       specify { _(parser.group).must_be_nil }
-      specify { _(parser.type).must_be_nil }
     end
 
     describe "multi-line with group" do
@@ -26,7 +24,6 @@ module KafoParsers
       specify { _(parser.doc).must_equal ["example parameter", "documentation"] }
       specify { _(parser.condition).must_be_nil }
       specify { _(parser.group).must_equal ["Advanced parameters"] }
-      specify { _(parser.type).must_be_nil }
     end
 
     describe "multi-line with nested group" do
@@ -34,15 +31,6 @@ module KafoParsers
       specify { _(parser.doc).must_equal ["example parameter", "documentation"] }
       specify { _(parser.condition).must_be_nil }
       specify { _(parser.group).must_equal ["Advanced parameters", "MySQL"] }
-      specify { _(parser.type).must_be_nil }
-    end
-
-    describe "multi-line with type" do
-      let(:doc) { ["example parameter", "     documentation", "    type: Optional[Hash[String, Array[Integer]]]"] }
-      specify { _(parser.doc).must_equal ["example parameter", "documentation"] }
-      specify { _(parser.condition).must_be_nil }
-      specify { _(parser.group).must_be_nil }
-      specify { _(parser.type).must_equal "Optional[Hash[String, Array[Integer]]]" }
     end
 
     describe "multi-line with condition" do
@@ -50,7 +38,6 @@ module KafoParsers
       specify { _(parser.doc).must_equal ["example parameter", "documentation"] }
       specify { _(parser.condition).must_equal "$db_type == 'sqlite'" }
       specify { _(parser.group).must_be_nil }
-      specify { _(parser.type).must_be_nil }
     end
   end
 end

--- a/test/kafo_parsers/puppet_strings_parser_test.rb
+++ b/test/kafo_parsers/puppet_strings_parser_test.rb
@@ -66,7 +66,6 @@ module KafoParsers
             specify { _(docs.keys).wont_include 'undocumented' }
             specify { _(docs['version']).must_equal ['some version number'] }
             specify { _(docs['multiline']).must_equal ['param with multiline', 'documentation', 'consisting of 3 lines'] }
-            specify { _(docs['typed']).wont_include 'type:bool' }
           end
 
           describe "parsed groups" do
@@ -84,16 +83,14 @@ module KafoParsers
           describe "parsed types" do
             let(:types) { data[:types] }
             specify { _(types['version']).must_equal 'Any' }
-            specify { _(types['typed']).must_equal 'boolean' }
-            specify { _(types['remote']).must_equal 'boolean' }
-            specify { _(types['multivalue']).must_match /^(array|Array\[String\])$/ }
-            specify { _(types['mapped']).must_match /^(hash|Hash\[String, Variant\[String, Integer\]\])$/ }
+            specify { _(types['remote']).must_equal 'Boolean' }
+            specify { _(types['multivalue']).must_equal('Array[String]') }
+            specify { _(types['mapped']).must_equal('Hash[String, Optional[String]]') }
           end
 
           describe "parsed conditions" do
             let(:conditions) { data[:conditions] }
             specify { _(conditions['version']).must_be_nil }
-            specify { _(conditions['typed']).must_be_nil }
             if manifest[:name] == "YARD class"
               specify { _(conditions['remote']).must_be_nil }
               specify { _(conditions['server']).must_equal '$remote' }

--- a/test/kafo_parsers/puppet_strings_parser_test.rb
+++ b/test/kafo_parsers/puppet_strings_parser_test.rb
@@ -19,7 +19,6 @@ module KafoParsers
           describe 'data structure' do
             let(:keys) { data.keys }
             specify { _(keys).must_include :values }
-            specify { _(keys).must_include :validations }
             specify { _(keys).must_include :docs }
             specify { _(keys).must_include :parameters }
             specify { _(keys).must_include :types }
@@ -56,11 +55,6 @@ module KafoParsers
             specify { _(values['mapped']).must_equal({'apples' => 'oranges', 'unquoted' => :undef}) }
             specify { _(values['debug']).must_equal 'true' }
             specify { _(values['variable']).must_equal '$::testing::params::variable' }
-          end
-
-          describe "parsed validations are not supported" do
-            let(:validations) { data[:validations] }
-            specify { _(validations).must_be_empty }
           end
 
           describe "parsed documentation" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,26 +24,20 @@ BASIC_MANIFEST = <<EOS
 # $multiline::       param with multiline
 #                    documentation
 #                    consisting of 3 lines
-# $typed::           something having it's type explicitly set
-#                    type:boolean
 # $multivalue::      list of users
-#                    type:array
 # $mapped::          some mapping
-#                    type:hash
 # === Advanced parameters
 #
 # $debug::           we have advanced parameter, yay!
-#                    type:boolean
 # $db_type::         can be mysql or sqlite
 #
 # ==== MySQL         condition: $db_type == 'mysql'
 #
 # $remote::          socket or remote connection
-#                    type: boolean
 # $server::          hostname
 #                    condition: $remote
 # $username::        username
-# $password::        type:password
+# $password::        db password
 #                    condition:$username != 'root'
 #
 # ==== Sqlite        condition: $db_type == 'sqlite'
@@ -60,15 +54,14 @@ class testing(
   $required,
   $version = '1.0',
   $sub_version = "beta",
-  $undocumented = 'does not have documentation',
+  String $undocumented = 'does not have documentation',
   $undef = undef,
   $multiline = undef,
-  $typed = true,
-  $multivalue = ['x', 'y'],
-  $mapped = {'apples' => 'oranges', unquoted => undef},
-  $debug = true,
+  Array[String] $multivalue = ['x', 'y'],
+  Hash[String, Optional[String]] $mapped = {'apples' => 'oranges', unquoted => undef},
+  Boolean $debug = true,
   $db_type = 'mysql',
-  $remote = true,
+  Boolean $remote = true,
   $server = 'mysql.example.com',
   $username = 'root',
   $password = 'toor',
@@ -76,7 +69,6 @@ class testing(
   $variable = $::testing::params::variable,
   $m_i_a = 'test') {
 
-  validate_string($undocumented)
   if $version == '1.0' {
     # this must be ignored since we can't evaluate conditions
     validate_bool($undef)
@@ -103,17 +95,16 @@ BASIC_YARD_MANIFEST = <<EOS
 # @param multiline           param with multiline
 #                            documentation
 #                            consisting of 3 lines
-# @param typed [boolean]     something having its type explicitly set
 # @param multivalue          list of users
 # @param mapped              some mapping
 # @param m_i_a
 #
-# @param debug [boolean]     we have advanced parameter, yay!
+# @param debug               we have advanced parameter, yay!
 #                            group:Advanced parameters
 # @param db_type             can be mysql or sqlite
 #                            group:Advanced parameters
 #
-# @param remote [boolean]    socket or remote connection
+# @param remote              socket or remote connection
 #                            group: Advanced parameters, MySQL
 # @param server              hostname
 #                            condition: $remote
@@ -136,12 +127,11 @@ class testing(
   String $undocumented = 'does not have documentation',
   Optional[Integer] $undef = undef,
   Optional[String] $multiline = undef,
-  $typed = true,
   Array[String] $multivalue = ['x', 'y'],
-  Hash[String, Variant[String, Integer]] $mapped = {'apples' => 'oranges', unquoted => undef},
+  Hash[String, Optional[String]] $mapped = {'apples' => 'oranges', unquoted => undef},
   $debug = true,
   Enum['mysql', 'sqlite'] $db_type = 'mysql',
-  $remote = true,
+  Boolean $remote = true,
   String $server = 'mysql.example.com',
   String $username = 'root',
   $password = 'toor',
@@ -149,7 +139,6 @@ class testing(
   String $variable = $::testing::params::variable,
   String $m_i_a = 'test') {
 
-  validate_string($undocumented)
   if $version == '1.0' {
     # this must be ignored since we can't evaluate conditions
     validate_bool($undef)


### PR DESCRIPTION
Previously it was possible to set data types via parameter documentation, but Puppet has native data types. It now relies on puppet-strings to parse these.

Includes https://github.com/theforeman/kafo_parsers/pull/39